### PR TITLE
Fix bug in `removeTodoItem`

### DIFF
--- a/src/addRemoveFunctions.js
+++ b/src/addRemoveFunctions.js
@@ -87,9 +87,10 @@ export const onSubmit = () => {
 
 export const removeCompleted = () => {
   const notCompletedList = todoList.data.filter((i) => !i.completed);
+  const todoElements = document.querySelectorAll('div.todo-item');
   todoList.data
     .filter((item) => item.completed)
-    .map((item) => document.querySelectorAll('div.todo-item')[item.index])
+    .map((item) => todoElements[item.index])
     .map((element) => element.remove());
 
   todoList.data = notCompletedList;

--- a/src/addRemoveFunctions.js
+++ b/src/addRemoveFunctions.js
@@ -12,15 +12,14 @@ const removeTodoItem = (todoElem) => {
   updateStorage(todoList.data);
 };
 
-const editTodoItem = (id, newValue) => {
-  todoList.data[parseInt(id, 10)].description = newValue;
+const editTodoItem = (item, newValue) => {
+  item.description = newValue;
   updateStorage(todoList.data);
 };
 
 export const createTodo = (item) => {
   const todoElem = document.createElement('div');
-  const id = item.index;
-  todoElem.id = id;
+  todoElem.id = item.index;
   todoElem.classList.add('todo-item');
   const innerHtml = `
       <input type="checkbox">
@@ -41,7 +40,7 @@ export const createTodo = (item) => {
   const deleteBtn = todoElem.querySelector('.icon.delete');
 
   inputBox.addEventListener('change', (e) => {
-    editTodoItem(todoElem.id, e.currentTarget.value);
+    editTodoItem(item, e.currentTarget.value);
   });
   inputBox.addEventListener('focus', () => {
     todoElem.style.backgroundColor = '#f4f5cc';
@@ -58,7 +57,7 @@ export const createTodo = (item) => {
   checkboxInput.checked = item.completed;
 
   checkboxInput.addEventListener('change', (e) => {
-    setCompleted(e, todoElem.id, inputBox);
+    setCompleted(e, item, inputBox);
   });
 
   deleteBtn.addEventListener('mousedown', () => {

--- a/src/addRemoveFunctions.js
+++ b/src/addRemoveFunctions.js
@@ -43,16 +43,20 @@ export const createTodo = (item) => {
     editTodoItem(item, e.currentTarget.value);
   });
   inputBox.addEventListener('focus', () => {
-    todoElem.style.backgroundColor = '#f4f5cc';
+    todoElem.classList.add('highlight');
+    inputBox.classList.remove('checked');
   });
   inputBox.addEventListener('blur', () => {
-    todoElem.style.backgroundColor = 'white';
+    todoElem.classList.remove('highlight');
+    if (item.completed) {
+      inputBox.classList.add('checked');
+    }
   });
 
   inputBox.value = item.description;
-  inputBox.style.textDecoration = (item.completed && 'line-through') || 'none';
-  inputBox.style.color = (item.completed && 'gray') || 'black';
-  inputBox.disabled = item.completed;
+  if (item.completed) {
+    inputBox.classList.add('checked');
+  }
 
   checkboxInput.checked = item.completed;
 

--- a/src/addRemoveFunctions.js
+++ b/src/addRemoveFunctions.js
@@ -6,6 +6,9 @@ const todoContainerElement = document.querySelector('.todo-container .todo-items
 const removeTodoItem = (todoElem) => {
   todoList.data.splice(todoElem.id, 1);
   todoElem.remove();
+  // reset todo elements indexes
+  todoContainerElement.querySelectorAll('.todo-item')
+    .forEach((item, idx) => { item.id = idx; });
   updateStorage(todoList.data);
 };
 

--- a/src/addRemoveFunctions.js
+++ b/src/addRemoveFunctions.js
@@ -13,7 +13,7 @@ const removeTodoItem = (todoElem) => {
 };
 
 const editTodoItem = (item, newValue) => {
-  item.description = newValue;
+  item.description = newValue.trim();
   updateStorage(todoList.data);
 };
 
@@ -41,6 +41,7 @@ export const createTodo = (item) => {
 
   inputBox.addEventListener('change', (e) => {
     editTodoItem(item, e.currentTarget.value);
+    e.currentTarget.value = e.currentTarget.value.trim();
   });
   inputBox.addEventListener('focus', () => {
     todoElem.classList.add('highlight');

--- a/src/setCompleted.js
+++ b/src/setCompleted.js
@@ -2,9 +2,11 @@ import { updateStorage, todoList } from './storage.js';
 
 export default (e, item, inputBox) => {
   item.completed = e.currentTarget.checked;
-  inputBox.style.textDecoration = (e.currentTarget.checked && 'line-through') || 'none';
-  inputBox.style.color = (e.currentTarget.checked && 'gray') || 'black';
-  inputBox.disabled = e.currentTarget.checked;
+  if (e.currentTarget.checked) {
+    inputBox.classList.add('checked');
+  } else {
+    inputBox.classList.remove('checked');
+  }
 
   updateStorage(todoList.data);
 };

--- a/src/setCompleted.js
+++ b/src/setCompleted.js
@@ -1,7 +1,7 @@
 import { updateStorage, todoList } from './storage.js';
 
-export default (e, id, inputBox) => {
-  todoList.data[parseInt(id, 10)].completed = e.currentTarget.checked;
+export default (e, item, inputBox) => {
+  item.completed = e.currentTarget.checked;
   inputBox.style.textDecoration = (e.currentTarget.checked && 'line-through') || 'none';
   inputBox.style.color = (e.currentTarget.checked && 'gray') || 'black';
   inputBox.disabled = e.currentTarget.checked;

--- a/src/storage.js
+++ b/src/storage.js
@@ -4,14 +4,14 @@ let timeout;
 const refreshIcon = document.getElementById('refresh-todo-icon');
 export const updateStorage = (newList) => {
   clearTimeout(timeout);
-  refreshIcon.style.opacity = 1;
+  refreshIcon.classList.add('active');
   // update todo items indexes
   newList.forEach((item, idx) => {
     item.index = idx;
   });
   localStorage.setItem(STORAGE_NAME, JSON.stringify(newList));
   timeout = setTimeout(() => {
-    refreshIcon.style.opacity = 0;
+    refreshIcon.classList.remove('active');
   }, 400);
 };
 

--- a/src/style.css
+++ b/src/style.css
@@ -61,6 +61,10 @@ input {
   animation: refresh-rotation 1s infinite linear;
 }
 
+#refresh-todo-icon.active {
+  opacity: 1;
+}
+
 #refresh-todo-icon i {
   vertical-align: middle;
 }
@@ -110,6 +114,10 @@ input {
   padding-left: 1rem;
 }
 
+.todo-item.highlight {
+  background-color: #f4f5cc;
+}
+
 .todo-item .input-box {
   display: flex;
   align-items: center;
@@ -122,6 +130,11 @@ input {
 .todo-item .input-box input {
   height: 100%;
   flex-grow: 1;
+}
+
+.todo-item .input-box input.checked {
+  text-decoration: line-through;
+  color: gray;
 }
 
 .clear-completed-container {


### PR DESCRIPTION
### Fixes

- Closes #4
- Fix bug in `removeTodo` where indexes are not reset in the HTML document
- Change setting inline styles to using classes instead.
-  Trimmed input value `onchange` in `input` event listener